### PR TITLE
Make animal growth random; closes #25

### DIFF
--- a/assets/prefabs/animals/babyDeer.prefab
+++ b/assets/prefabs/animals/babyDeer.prefab
@@ -56,7 +56,10 @@
     "icon": "WildAnimals:deerIcon"
   },
   "WildAnimalGrowth": {
-    "timeToGrowth": 15000,
+    "timeToGrowth": {
+      "fixed": 15000,
+      "maxRandom": 5000
+    },
     "nextStagePrefab": "WildAnimals:deer"
   },
   "NPCMovement": {},

--- a/src/main/java/org/terasology/wildAnimals/WildAnimalsGrowthSystem.java
+++ b/src/main/java/org/terasology/wildAnimals/WildAnimalsGrowthSystem.java
@@ -42,7 +42,7 @@ public class WildAnimalsGrowthSystem extends BaseComponentSystem {
 
     @ReceiveEvent(components = {WildAnimalComponent.class})
     public void onGrowthComponentActivated(OnActivatedComponent event, EntityRef entityRef, WildAnimalGrowthComponent wildAnimalGrowthComponent) {
-        delayManager.addDelayedAction(entityRef, GROWTH_ID, wildAnimalGrowthComponent.timeToGrowth);
+        delayManager.addDelayedAction(entityRef, GROWTH_ID, wildAnimalGrowthComponent.timeToGrowth.sample());
     }
 
     @ReceiveEvent(components = {WildAnimalComponent.class})

--- a/src/main/java/org/terasology/wildAnimals/component/WildAnimalGrowthComponent.java
+++ b/src/main/java/org/terasology/wildAnimals/component/WildAnimalGrowthComponent.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.wildAnimals.component;
 
+import org.terasology.core.logic.random.Interval;
 import org.terasology.entitySystem.Component;
 
 /**
@@ -22,9 +23,9 @@ import org.terasology.entitySystem.Component;
  */
 public class WildAnimalGrowthComponent implements Component {
     /**
-     * The time the animal will stay in this stage.
+     * The time range the animal will stay in this stage, expressed in ms.
      */
-    public long timeToGrowth;
+    public Interval timeToGrowth;
 
     /**
      * The prefab for the next stage the animal will grow into.


### PR DESCRIPTION
### Contains

Baby deer now take a random time between 15 and 20 seconds to mature, instead of exactly 15 seconds, closing #25.

### How to test

Boot up the game and spawn several baby deer with `spawnPrefab babyDeer` in quick succession.  They should not all mature at the same time.

### Outstanding before merging

This PR depends on the PR MovingBlocks/Terasology#3129, which moves the `TimeRange` class from `SimpleFarming` into the `Core` module (and renaming it `Interval`), thereby making it available to this module.  That PR should therefore be merged first.
