### PR TITLE
Make animal growth random; closes #25 (revised)

### DIFF
--- a/assets/prefabs/animals/babyDeer.prefab
+++ b/assets/prefabs/animals/babyDeer.prefab
@@ -56,7 +56,8 @@
     "icon": "WildAnimals:deerIcon"
   },
   "WildAnimalGrowth": {
-    "timeToGrowth": 15000,
+    "minGrowthTime": 15000,
+    "maxGrowthTime": 30000,
     "nextStagePrefab": "WildAnimals:deer"
   },
   "NPCMovement": {},

--- a/src/main/java/org/terasology/wildAnimals/component/WildAnimalGrowthComponent.java
+++ b/src/main/java/org/terasology/wildAnimals/component/WildAnimalGrowthComponent.java
@@ -22,9 +22,14 @@ import org.terasology.entitySystem.Component;
  */
 public class WildAnimalGrowthComponent implements Component {
     /**
-     * The time the animal will stay in this stage.
+     * The minimum time the animal will stay in this stage, in milliseconds.
      */
-    public long timeToGrowth;
+    public long minGrowthTime;
+
+    /**
+     * The maximum time the animal will stay in this stage, in milliseconds.
+     */
+    public long maxGrowthTime;
 
     /**
      * The prefab for the next stage the animal will grow into.


### PR DESCRIPTION
### Contains

Baby deer now take a random time between 15 and 30 seconds to mature, instead of exactly 15 seconds, closing #25.

This is a replacement for PR #26, which ran afoul of some cross-module coordination issues.

### How to test

Boot up the game and spawn several baby deer with `spawnPrefab babyDeer` in quick succession.  They should all mature within 30 seconds but not all at the same time.

### Outstanding before merging

Nothing.