### PR TITLE
Expose spawn configuration options to other modules

### DIFF
--- a/src/main/java/org/terasology/wildAnimals/AnimalSpawnConfig.java
+++ b/src/main/java/org/terasology/wildAnimals/AnimalSpawnConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.wildAnimals;
+
+public class AnimalSpawnConfig {
+    public final int MIN_GROUND_PER_DEER = 5;
+    public final int MIN_DEER_GROUP_SIZE = 4;
+    public final int MAX_DEER_GROUP_SIZE = 10;
+    public final int SPAWN_CHANCE_IN_PERCENT = 10;
+}

--- a/src/main/java/org/terasology/wildAnimals/system/WildAnimalsSpawnSystem.java
+++ b/src/main/java/org/terasology/wildAnimals/system/WildAnimalsSpawnSystem.java
@@ -29,6 +29,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 import org.terasology.utilities.Assets;
+import org.terasology.wildAnimals.AnimalSpawnConfig;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
@@ -42,7 +43,7 @@ import java.util.function.Function;
 @Share(value = WildAnimalsSpawnSystem.class)
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class WildAnimalsSpawnSystem extends BaseComponentSystem {
-    private Configuration config;
+    private AnimalSpawnConfig config;
 
     @In
     private EntityManager entityManager;
@@ -100,7 +101,7 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
         }
 
         if (config == null) {
-            config = new Configuration();
+            config = new AnimalSpawnConfig();
         }
     }
 
@@ -108,7 +109,7 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
         isValidSpawnPosition = function;
     }
 
-    public void setConfig(Configuration configuration) {
+    public void setConfig(AnimalSpawnConfig configuration) {
         config = configuration;
     }
 
@@ -191,13 +192,6 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
         Quat4f rotation = new Quat4f(yAxis, randomAngle);
         // TODO Turn deer spawning back on when done with debugging - this and the SPAWN_CHANCE_IN_PERCENT constant.
         entityManager.create(deerPrefab, floatVectorLocation, rotation);
-    }
-
-    public static class Configuration {
-        public int MIN_GROUND_PER_DEER = 5;
-        public int MIN_DEER_GROUP_SIZE = 4;
-        public int MAX_DEER_GROUP_SIZE = 10;
-        public int SPAWN_CHANCE_IN_PERCENT = 10;
     }
 
 }

--- a/src/main/java/org/terasology/wildAnimals/system/WildAnimalsSpawnSystem.java
+++ b/src/main/java/org/terasology/wildAnimals/system/WildAnimalsSpawnSystem.java
@@ -16,7 +16,6 @@
 package org.terasology.wildAnimals.system;
 
 import com.google.common.collect.Lists;
-import org.terasology.utilities.Assets;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -28,6 +27,8 @@ import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
+import org.terasology.registry.Share;
+import org.terasology.utilities.Assets;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
@@ -36,13 +37,12 @@ import org.terasology.world.chunks.event.OnChunkGenerated;
 
 import java.util.List;
 import java.util.Random;
+import java.util.function.Function;
 
+@Share(value = WildAnimalsSpawnSystem.class)
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class WildAnimalsSpawnSystem extends BaseComponentSystem {
-    private static final int MIN_GROUND_PER_DEER = 5;
-    private static final int MIN_DEER_GROUP_SIZE = 4;
-    private static final int MAX_DEER_GROUP_SIZE = 10;
-    private static final int SPAWN_CHANCE_IN_PERCENT = 0;
+    private Configuration config;
 
     @In
     private EntityManager entityManager;
@@ -63,8 +63,12 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
     private Prefab greenDeerPrefab;
     private Prefab blueDeerPrefab;
 
-    
-    
+    /**
+     * Check blocks at and around the target position and check if it's a valid spawning spot
+     */
+    private Function<Vector3i, Boolean> isValidSpawnPosition;
+
+
     /**
      * Readies the spawning system by defining blocks for identification and obtaining prefabs of animals.
      */
@@ -76,54 +80,85 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
         redDeerPrefab = Assets.getPrefab("WildAnimals:RedDeer").get();
         greenDeerPrefab = Assets.getPrefab("WildAnimals:GreenDeer").get();
         blueDeerPrefab = Assets.getPrefab("WildAnimals:BlueDeer").get();
+
+        if (isValidSpawnPosition == null) {
+            isValidSpawnPosition = pos -> {
+                Vector3i below = new Vector3i(pos.x, pos.y - 1, pos.z);
+                Block blockBelow = worldProvider.getBlock(below);
+                if (!blockBelow.equals(grassBlock)) {
+                    return false;
+                }
+                Block blockAtPosition = worldProvider.getBlock(pos);
+                if (!blockAtPosition.isPenetrable()) {
+                    return false;
+                }
+
+                Vector3i above = new Vector3i(pos.x, pos.y + 1, pos.z);
+                Block blockAbove = worldProvider.getBlock(above);
+                return blockAbove.equals(airBlock);
+            };
+        }
+
+        if (config == null) {
+            config = new Configuration();
+        }
     }
-    
+
+    public void setSpawnCondition(Function<Vector3i, Boolean> function) {
+        isValidSpawnPosition = function;
+    }
+
+    public void setConfig(Configuration configuration) {
+        config = configuration;
+    }
+
+
     /**
      * Runs upon a chunk being generated to see whether a deer should be spawned
      *
-     * @param event         The event which the method will run upon receiving
-     * @param worldEntity   The world that the chunk is in
+     * @param event       The event which the method will run upon receiving
+     * @param worldEntity The world that the chunk is in
      */
     @ReceiveEvent
     public void onChunkGenerated(OnChunkGenerated event, EntityRef worldEntity) {
-        boolean trySpawn = SPAWN_CHANCE_IN_PERCENT > random.nextInt(100);
+        boolean trySpawn = config.SPAWN_CHANCE_IN_PERCENT > random.nextInt(100);
         if (!trySpawn) {
             return;
         }
         Vector3i chunkPos = event.getChunkPos();
         tryDeerSpawn(chunkPos);
     }
-    
+
     /**
      * Attempts to spawn deer on the specified chunk. The number of deers spawned will depend on probabiliy
      * configurations defined earlier.
      *
-     * @param chunkPos   The chunk which the game will try to spawn deers on
+     * @param chunkPos The chunk which the game will try to spawn deers on
      */
     private void tryDeerSpawn(Vector3i chunkPos) {
         List<Vector3i> foundPositions = findDeerSpawnPositions(chunkPos);
 
-        if (foundPositions.size() < MIN_DEER_GROUP_SIZE * MIN_GROUND_PER_DEER) {
+        if (foundPositions.size() < config.MIN_DEER_GROUP_SIZE * config.MIN_GROUND_PER_DEER) {
             return;
         }
 
-        int maxDeerCount = foundPositions.size() / MIN_DEER_GROUP_SIZE;
-        if (maxDeerCount > MAX_DEER_GROUP_SIZE) {
-            maxDeerCount = MAX_DEER_GROUP_SIZE;
+        int maxDeerCount = foundPositions.size() / config.MIN_DEER_GROUP_SIZE;
+        if (maxDeerCount > config.MAX_DEER_GROUP_SIZE) {
+            maxDeerCount = config.MAX_DEER_GROUP_SIZE;
         }
-        int deerCount = random.nextInt(maxDeerCount - MIN_DEER_GROUP_SIZE) + MIN_DEER_GROUP_SIZE;
+        int deerCount = random.nextInt(maxDeerCount - config.MIN_DEER_GROUP_SIZE) + config.MIN_DEER_GROUP_SIZE;
 
-        for (int i = 0; i < deerCount; i++ ) {
+        for (int i = 0; i < deerCount; i++) {
             int randomIndex = random.nextInt(foundPositions.size());
             Vector3i randomSpawnPosition = foundPositions.remove(randomIndex);
             spawnDeer(randomSpawnPosition);
         }
     }
-    
+
     /**
      * Checks each block of the chunk specified for valid spawning spawnings point for deer.
      *
-     * @param chunkPos  The chunk that is being checked for valid spawnpoints
+     * @param chunkPos The chunk that is being checked for valid spawnpoints
      * @return a list of positions of potential deer spawnpoints
      */
     private List<Vector3i> findDeerSpawnPositions(Vector3i chunkPos) {
@@ -135,7 +170,7 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
             for (int z = 0; z < ChunkConstants.SIZE_Z; z++) {
                 for (int x = 0; x < ChunkConstants.SIZE_X; x++) {
                     blockPos.set(x + worldPos.x, y + worldPos.y, z + worldPos.z);
-                    if (isValidSpawnPosition(blockPos)) {
+                    if (isValidSpawnPosition.apply(blockPos)) {
                         foundPositions.add(new Vector3i(blockPos));
                     }
                 }
@@ -143,44 +178,26 @@ public class WildAnimalsSpawnSystem extends BaseComponentSystem {
         }
         return foundPositions;
     }
-    
+
     /**
      * Spawns the deer at the location specified by the parameter.
      *
-     * @param location   The location where the deer is to be spawned
+     * @param location The location where the deer is to be spawned
      */
     private void spawnDeer(Vector3i location) {
         Vector3f floatVectorLocation = location.toVector3f();
         Vector3f yAxis = new Vector3f(0, 1, 0);
-        float randomAngle = (float) (random.nextFloat()*Math.PI*2);
+        float randomAngle = (float) (random.nextFloat() * Math.PI * 2);
         Quat4f rotation = new Quat4f(yAxis, randomAngle);
         // TODO Turn deer spawning back on when done with debugging - this and the SPAWN_CHANCE_IN_PERCENT constant.
-        // entityManager.create(deerPrefab, floatVectorLocation, rotation);
+        entityManager.create(deerPrefab, floatVectorLocation, rotation);
     }
 
-    /**
-     * Check blocks at and around the target position and check if it's a valid spawning spot
-     *
-     * @param pos   The block to be checked if it's a valid spot for spawning
-     * @return A boolean with the value of true if the block is a valid spot for spawing
-     */
-    private boolean isValidSpawnPosition(Vector3i pos) {
-        Vector3i below = new Vector3i(pos.x, pos.y-1, pos.z);
-        Block blockBelow= worldProvider.getBlock(below);
-        if (!blockBelow.equals(grassBlock)) {
-            return false;
-        }
-        Block blockAtPosition = worldProvider.getBlock(pos);
-        if (!blockAtPosition.isPenetrable()) {
-            return false;
-        }
-
-        Vector3i above = new Vector3i(pos.x, pos.y+1, pos.z);
-        Block blockAbove= worldProvider.getBlock(above);
-        if (!blockAbove.equals(airBlock)) {
-            return false;
-        }
-        return true;
+    public static class Configuration {
+        public int MIN_GROUND_PER_DEER = 5;
+        public int MIN_DEER_GROUP_SIZE = 4;
+        public int MAX_DEER_GROUP_SIZE = 10;
+        public int SPAWN_CHANCE_IN_PERCENT = 10;
     }
 
 }


### PR DESCRIPTION
If a module wishes to change the way spawn works, create a new system in that module which uses the `setConfig` and `setSpawnCondition` functions to pass custom configuration options and spawn conditions.