### PR TITLE
Changed prefabs for RBG Deers

### DIFF
--- a/assets/prefabs/animals/blueDeer.prefab
+++ b/assets/prefabs/animals/blueDeer.prefab
@@ -1,4 +1,5 @@
 {
+  "parent" : "greenDeer",
   "skeletalmesh" : {
     "mesh" : "deer",
     "heightOffset" : -0.8,
@@ -8,68 +9,5 @@
   },
   "Behavior" : {
     "tree" : "Behaviors:critter"
-  },
-  "FleeOnHit" : {
-    "minDistance" : 5
-  },
-  "BlockDropGrammar": {
-    "blockDrops": [],
-    "itemDrops": ["2*WildAnimals:meat"]
-  },
-  "Stand" :{
-    "animationPool": [
-      "deerIdle",
-      "deerIdle",
-      "deerIdle",
-      "deerIdleLookLeft",
-      "deerIdleLookRight",
-      "deerIdleMoveLegs"
-      ]
-  },
-  "Walk" :{
-    "animationPool": ["deerWalk"]
-  },
-  "Die" :{
-    "animationPool": ["deerFall"]
-  },
-  "persisted" : true,
-  "location" : {},
-  "Character" : {},
-  "AliveCharacter": {},
-  "WildAnimal" : {
-    "name": "BlueDeer",
-    "icon": "WildAnimals:deerIcon"
-  },
-  "NPCMovement" : {},
-  "CreatureNameGenerator" : {
-    "genderRatio" : 0,
-    "nobility" : 0,
-    "theme": "ANIMAL"
-  },
-  "CharacterMovement" : {
-    "groundFriction" : 16,
-    "speedMultiplier" : 0.3,
-    "distanceBetweenFootsteps" : 0.2,
-    "distanceBetweenSwimStrokes" : 2.5,
-    "height" : 1.6,
-    "radius" : 0.3,
-    "jumpSpeed" : 12
-  },
-  "CharacterSound" : {
-    "footstepSounds" : ["FootGrass1", "FootGrass2", "FootGrass3", "FootGrass4", "FootGrass5"],
-    "footstepVolume" : 0.03
-  },
-  "Network" :{},
-  "MinionMove" : {},
-  "Health" : {
-    "destroyEntityOnNoHealth" : true,
-    "currentHealth": 50,
-    "maxHealth": 50
-  },
-  "BoxShape" : {
-    "extents" : [1.5, 1.5, 1.5]
-  },
-  "Trigger" : {
-    "detectGroups" : ["engine:debris", "engine:sensor"]
   }
 }

--- a/assets/prefabs/animals/greenDeer.prefab
+++ b/assets/prefabs/animals/greenDeer.prefab
@@ -6,9 +6,6 @@
     "animation" : "deerIdle",
     "loop" : true
   },
-  "Behavior" : {
-    "tree" : "Behaviors:critter"
-  },
   "FleeOnHit" : {
     "minDistance" : 5
   },

--- a/assets/prefabs/animals/redDeer.prefab
+++ b/assets/prefabs/animals/redDeer.prefab
@@ -1,4 +1,5 @@
 {
+  "parent" : "deer",
   "skeletalmesh" : {
     "mesh" : "deer",
     "heightOffset" : -0.8,
@@ -8,68 +9,5 @@
   },
   "Behavior" : {
     "tree" : "Behaviors:critter"
-  },
-  "FleeOnHit" : {
-    "minDistance" : 5
-  },
-  "BlockDropGrammar": {
-    "blockDrops": [],
-    "itemDrops": ["2*WildAnimals:meat"]
-  },
-  "Stand" :{
-    "animationPool": [
-      "deerIdle",
-      "deerIdle",
-      "deerIdle",
-      "deerIdleLookLeft",
-      "deerIdleLookRight",
-      "deerIdleMoveLegs"
-      ]
-  },
-  "Walk" :{
-    "animationPool": ["deerWalk"]
-  },
-  "Die" :{
-    "animationPool": ["deerFall"]
-  },
-  "persisted" : true,
-  "location" : {},
-  "Character" : {},
-  "AliveCharacter": {},
-  "WildAnimal" : {
-    "name": "RedDeer",
-    "icon": "WildAnimals:deerIcon"
-  },
-  "NPCMovement" : {},
-  "CreatureNameGenerator" : {
-    "genderRatio" : 0,
-    "nobility" : 0,
-    "theme": "ANIMAL"
-  },
-  "CharacterMovement" : {
-    "groundFriction" : 16,
-    "speedMultiplier" : 0.3,
-    "distanceBetweenFootsteps" : 0.2,
-    "distanceBetweenSwimStrokes" : 2.5,
-    "height" : 1.6,
-    "radius" : 0.3,
-    "jumpSpeed" : 12
-  },
-  "CharacterSound" : {
-    "footstepSounds" : ["FootGrass1", "FootGrass2", "FootGrass3", "FootGrass4", "FootGrass5"],
-    "footstepVolume" : 0.03
-  },
-  "Network" :{},
-  "MinionMove" : {},
-  "Health" : {
-    "destroyEntityOnNoHealth" : true,
-    "currentHealth": 50,
-    "maxHealth": 50
-  },
-  "BoxShape" : {
-    "extents" : [1.5, 1.5, 1.5]
-  },
-  "Trigger" : {
-    "detectGroups" : ["engine:debris", "engine:sensor"]
   }
 }


### PR DESCRIPTION
### Contains
- Changes in the RGB deers prefabs to match the alterations in the prefab tutorial.

### Objective
Exercise the usage of prefab inheritance.

### Changes

- `redDeer`: has the original `deer` as parent and contains only the `skeletalmesh`and the `Behavior` components (assigned behavior: `Behavior:critter`)
- `greenDeer`: has the same content of the original `deer` prefab, minus the `Behavior` component
- `blueDeer`: has `greenDeer` as parent and contains only the `skeletalmesh`and the `Behavior` components (assigned behavior: `Behavior:critter`)


### Usage

In the console (F1), type `spawnPrefab` followed by one of the new prefabs:

- `spawnPrefab redDeer`
- `spawnPrefab greenDeer`
- `spawnPrefab blueDeer`
