### PR TITLE
Fix typo in run behavior

### DIFF
--- a/assets/behaviors/run.behavior
+++ b/assets/behaviors/run.behavior
@@ -7,7 +7,7 @@
     }
   },
   {
-    set_mad_speed : {
+    set_speed : {
       speedMultiplier: 2.5
     }
 


### PR DESCRIPTION
The action "set_mad_speed" isn't recognised (which sometimes leads to a crash during deserialisation). I'm pretty sure this was meant to be just "set_speed", which does exist, and which has the same parameter that's used here.