### PR TITLE
fix: play animal damage sounds for all clients

### DIFF
--- a/assets/prefabs/animals/deer.prefab
+++ b/assets/prefabs/animals/deer.prefab
@@ -62,14 +62,16 @@
   },
   "CharacterSound": {
     "footstepSounds": [
-      "FootGrass1",
-      "FootGrass2",
-      "FootGrass3",
-      "FootGrass4",
-      "FootGrass5"
+      "engine:FootGrass1",
+      "engine:FootGrass2",
+      "engine:FootGrass3",
+      "engine:FootGrass4",
+      "engine:FootGrass5"
     ],
-    "footstepVolume": 0.03,
-    "damageSounds": [
+    "footstepVolume": 0.03
+  },
+  "DamageSound": {
+    "sounds": [
       "DeerHit1",
       "DeerHit2"
     ]

--- a/assets/prefabs/animals/sheepBase.prefab
+++ b/assets/prefabs/animals/sheepBase.prefab
@@ -58,7 +58,7 @@
     ],
     "footstepVolume": 0.03
   },
-  "DamageSoundComponent": {
+  "DamageSound": {
     "sounds": [
       "SheepHit1",
       "SheepHit2"

--- a/assets/prefabs/animals/sheepBase.prefab
+++ b/assets/prefabs/animals/sheepBase.prefab
@@ -50,14 +50,16 @@
   },
   "CharacterSound": {
     "footstepSounds": [
-      "FootGrass1",
-      "FootGrass2",
-      "FootGrass3",
-      "FootGrass4",
-      "FootGrass5"
+      "engine:FootGrass1",
+      "engine:FootGrass2",
+      "engine:FootGrass3",
+      "engine:FootGrass4",
+      "engine:FootGrass5"
     ],
-    "footstepVolume": 0.03,
-    "damageSounds": [
+    "footstepVolume": 0.03
+  },
+  "DamageSoundComponent": {
+    "sounds": [
       "SheepHit1",
       "SheepHit2"
     ]


### PR DESCRIPTION
The damage sounds from the `CharacterSoundComponent` are only played for the owner of that entity, i.e., they are intended for sounds that are audible to the player, but not to others.

In contrast, the damage sounds from the `DamageSound` component are played for all clients, not just the owner of the entity.

Therefore, we move the damage sound specification from `CharacterSound` to `DamageSound` in the animal prefabs that define damage sound assets.
