### PR TITLE
fix: add missing FleeComponent properties

### DIFF
--- a/assets/prefabs/animals/babyDeer.prefab
+++ b/assets/prefabs/animals/babyDeer.prefab
@@ -64,11 +64,9 @@
     "nobility": 0.5,
     "theme": "DWARF"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/bat.prefab
+++ b/assets/prefabs/animals/bat.prefab
@@ -51,11 +51,9 @@
     "nobility": 0.5,
     "theme": "DWARF"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/bat.prefab
+++ b/assets/prefabs/animals/bat.prefab
@@ -15,7 +15,8 @@
     "tree": "Behaviors:critter"
   },
   "FleeOnHit": {
-    "minDistance": 5
+    "minDistance": 5,
+    "speedMultiplier": 1.2
   },
   "DropGrammar": {
     "blockDrops": [],

--- a/assets/prefabs/animals/chicken.prefab
+++ b/assets/prefabs/animals/chicken.prefab
@@ -15,7 +15,8 @@
     "tree": "Behaviors:critter"
   },
   "FleeOnHit": {
-    "minDistance": 5
+    "minDistance": 5,
+    "speedMultiplier": 1.2
   },
   "DropGrammar": {
     "blockDrops": [],

--- a/assets/prefabs/animals/chicken.prefab
+++ b/assets/prefabs/animals/chicken.prefab
@@ -59,11 +59,9 @@
     "nobility": 0.5,
     "theme": "DWARF"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/crab.prefab
+++ b/assets/prefabs/animals/crab.prefab
@@ -62,11 +62,9 @@
     "nobility": 0.5,
     "theme": "DWARF"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/deer.prefab
+++ b/assets/prefabs/animals/deer.prefab
@@ -52,11 +52,9 @@
     "nobility": 0,
     "theme": "ANIMAL"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/deer.prefab
+++ b/assets/prefabs/animals/deer.prefab
@@ -10,7 +10,8 @@
     "tree": "Behaviors:critter"
   },
   "FleeOnHit": {
-    "minDistance": 5
+    "minDistance": 5,
+    "speedMultiplier": 1.2
   },
   "DropGrammar": {
     "blockDrops": [],

--- a/assets/prefabs/animals/friendlyDeer.prefab
+++ b/assets/prefabs/animals/friendlyDeer.prefab
@@ -9,6 +9,10 @@
   "Behavior": {
     "tree": "Behaviors:friendlyCritter"
   },
+  "FleeOnHit": {
+    "minDistance": 5,
+    "speedMultiplier": 1.2
+  },
   "FindNearbyPlayers": {
     "searchRadius": 8
   },

--- a/assets/prefabs/animals/friendlyDeer.prefab
+++ b/assets/prefabs/animals/friendlyDeer.prefab
@@ -59,11 +59,9 @@
     "nobility": 0,
     "theme": "ANIMAL"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/hostileDeer.prefab
+++ b/assets/prefabs/animals/hostileDeer.prefab
@@ -68,11 +68,9 @@
     "nobility": 0.5,
     "theme": "DWARF"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/hostileDeer.prefab
+++ b/assets/prefabs/animals/hostileDeer.prefab
@@ -12,6 +12,14 @@
   "AttackInProximity": {
     "speedMultiplier": 1.2
   },
+  "AttackOnHit": {
+    "minDistance": 5,
+    "speedMultiplier": 1.2
+  },
+  "FleeOnHit": {
+    "minDistance": 5,
+    "speedMultiplier": 1.2
+  },
   "FindNearbyPlayers": {
     "searchRadius": 10
   },

--- a/assets/prefabs/animals/insensitiveDeer.prefab
+++ b/assets/prefabs/animals/insensitiveDeer.prefab
@@ -52,11 +52,9 @@
     "nobility": 0,
     "theme": "ANIMAL"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/scaredDeer.prefab
+++ b/assets/prefabs/animals/scaredDeer.prefab
@@ -9,6 +9,10 @@
   "Behavior": {
     "tree": "Behaviors:scaredCritter"
   },
+  "FleeOnHit": {
+    "minDistance": 5,
+    "speedMultiplier": 1.2
+  },
   "FindNearbyPlayers": {
     "searchRadius": 8
   },

--- a/assets/prefabs/animals/scaredDeer.prefab
+++ b/assets/prefabs/animals/scaredDeer.prefab
@@ -59,11 +59,9 @@
     "nobility": 0,
     "theme": "ANIMAL"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/sheepBase.prefab
+++ b/assets/prefabs/animals/sheepBase.prefab
@@ -40,11 +40,9 @@
     "nobility": 0,
     "theme": "ANIMAL"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12

--- a/assets/prefabs/animals/sheepBase.prefab
+++ b/assets/prefabs/animals/sheepBase.prefab
@@ -3,7 +3,8 @@
     "tree": "Behaviors:critter"
   },
   "FleeOnHit": {
-    "minDistance": 5
+    "minDistance": 5,
+    "speedMultiplier": 1.2
   },
   "Stand": {
     "animationPool": [

--- a/assets/prefabs/animals/territorialDeer.prefab
+++ b/assets/prefabs/animals/territorialDeer.prefab
@@ -20,8 +20,9 @@
     "searchRadius": 5
   },
   "AttackOnHit": {
-    "minDistance": 5
-  },
+    "minDistance": 5,
+    "speedMultiplier": 1.2
+  },  
   "DropGrammar": {
     "blockDrops": [],
     "itemDrops": [

--- a/assets/prefabs/animals/territorialDeer.prefab
+++ b/assets/prefabs/animals/territorialDeer.prefab
@@ -61,11 +61,9 @@
     "nobility": 0,
     "theme": "ANIMAL"
   },
-  "CharacterMovement": {
-    "groundFriction": 16,
+  "CharacterMovement": {    
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,
-    "distanceBetweenSwimStrokes": 2.5,
+    "distanceBetweenFootsteps": 0.2,    
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12


### PR DESCRIPTION
The missing `speedMultiplier` property in the `FleeComponent` present in some prefabs is related to issue https://github.com/Terasology/MetalRenegades/issues/175 . This PR fixes all animals prefabs affected by this problem.