### PR TITLE
chore: remove reference to non-existant component

### DIFF
--- a/assets/prefabs/animals/aggressiveDeer.prefab
+++ b/assets/prefabs/animals/aggressiveDeer.prefab
@@ -13,9 +13,6 @@
     "maxDistance": 15,
     "speedMultiplier": 1.2
   },
-  "StrayIfIdle": {
-    "defaultSpeedMultiplier": 0.3
-  },
   "DropGrammar": {
     "blockDrops": [],
     "itemDrops": [

--- a/assets/prefabs/animals/babyDeer.prefab
+++ b/assets/prefabs/animals/babyDeer.prefab
@@ -18,9 +18,6 @@
     "minDistance": 5,
     "speedMultiplier": 1.2
   },
-  "StrayIfIdle": {
-    "defaultSpeedMultiplier": 0.3
-  },
   "DropGrammar": {
     "blockDrops": [],
     "itemDrops": [

--- a/assets/prefabs/animals/crab.prefab
+++ b/assets/prefabs/animals/crab.prefab
@@ -18,9 +18,6 @@
     "minDistance": 5,
     "speedMultiplier": 1.2
   },
-  "StrayIfIdle": {
-    "defaultSpeedMultiplier": 0.3
-  },
   "DropGrammar": {
     "blockDrops": [],
     "itemDrops": [

--- a/assets/prefabs/animals/hostileDeer.prefab
+++ b/assets/prefabs/animals/hostileDeer.prefab
@@ -23,9 +23,6 @@
   "FindNearbyPlayers": {
     "searchRadius": 10
   },
-  "StrayIfIdle": {
-    "defaultSpeedMultiplier": 0.3
-  },
   "DropGrammar": {
     "blockDrops": [],
     "itemDrops": [


### PR DESCRIPTION
Removes reference to `StrayIfIdle` which I wasn't able to find anywhere in omega.
This will resolve the logged warning reported in https://github.com/MovingBlocks/Terasology/issues/4981#issuecomment-1014781143