### PR TITLE
chore: FlexiblePathfinding migration follow-ups

### DIFF
--- a/assets/behaviors/lure.behavior
+++ b/assets/behaviors/lure.behavior
@@ -1,24 +1,20 @@
 {
   dynamic: [
-      {
-        guard: {
-          componentPresent: "Behaviors:FindNearbyPlayers",
-          values: ["N charactersWithinRange nonEmpty"],
-          child: {
+    {
+      guard: {
+        componentPresent: "Behaviors:FindNearbyPlayers",
+        values: ["N charactersWithinRange nonEmpty"],
+        child: {
           sequence: [
-            { sleep: {time: 0.1f }},
+            { sleep: { time: 0.1f } },
             check_luring_item_in_use,
             followCharacter,
-            { lookup: {tree: "Behaviors:follow" }}
-           ]
-          }
-        }
-      },
-      {
-        lookup: {
-          tree: "Behaviors:stray"
+            { lookup: { tree: "Behaviors:follow" } }
+          ]
         }
       }
+    },
+    { lookup: { tree: "Behaviors:stray" } }
   ]
 }
 

--- a/assets/prefabs/animals/deer.prefab
+++ b/assets/prefabs/animals/deer.prefab
@@ -1,60 +1,26 @@
 {
-  "skeletalmesh" : {
-    "mesh" : "deer",
-    "heightOffset" : -0.8,
-    "material" : "deerSkin",
-    "animation" : "deer#Idle",
-    "loop" : true
+  // -- Properties ----------------------------------------
+  "persisted": true,
+  // -- Components ----------------------------------------
+  "AliveCharacter": {},
+  "BaseRegen": {
+    "regenRate": 2,
+    "waitBeforeRegen": 10
   },
   "Behavior": {
     "tree": "Behaviors:critter"
   },
-  "FleeOnHit": {
-    "minDistance": 5,
-    "speedMultiplier": 1.2
-  },
-  "DropGrammar": {
-    "blockDrops": [],
-    "itemDrops": [
-      "0.7|WildAnimals:meat",
-      "0.3|WildAnimals:deerHide"
+  "BoxShape": {
+    "extents": [
+      1.5,
+      1.5,
+      1.5
     ]
   },
-  "Stand": {
-    "animationPool": [
-      "deer#Idle",
-      "deer#Idle",
-      "deer#Idle",
-      "deer#Bite_InPlace",
-      "deer#Yes",
-      "deer#No"
-      ]
-  },
-  "Walk" :{
-    "animationPool": ["deer#Walk"]
-  },
-  "Die": {
-    "animationPool": [
-      "deer#Death"
-    ]
-  },
-  "persisted": true,
-  "location": {},
   "Character": {},
-  "AliveCharacter": {},
-  "WildAnimal": {
-    "name": "Deer",
-    "icon": "WildAnimals:icons#Deer"
-  },
-  "NPCMovement": {},
-  "CreatureNameGenerator": {
-    "genderRatio": 0,
-    "nobility": 0,
-    "theme": "ANIMAL"
-  },
-  "CharacterMovement": {    
+  "CharacterMovement": {
     "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,    
+    "distanceBetweenFootsteps": 0.2,
     "height": 1.6,
     "radius": 0.3,
     "jumpSpeed": 12
@@ -69,30 +35,59 @@
     ],
     "footstepVolume": 0.03
   },
+  "CreatureNameGenerator": {
+    "genderRatio": 0,
+    "nobility": 0,
+    "theme": "ANIMAL"
+  },
   "DamageSound": {
     "sounds": [
       "DeerHit1",
       "DeerHit2"
     ]
   },
-  "Network": {},
-  "MinionMove": {
-    "movementTypes": ["walking", "leaping", "falling"]
+  "Die": {
+    "animationPool": [
+      "deer#Death"
+    ]
+  },
+  "DropGrammar": {
+    "blockDrops": [],
+    "itemDrops": [
+      "0.7|WildAnimals:meat",
+      "0.3|WildAnimals:deerHide"
+    ]
+  },
+  "FleeOnHit": {
+    "minDistance": 5,
+    "speedMultiplier": 1.2
   },
   "Health": {
     "destroyEntityOnNoHealth": true,
     "currentHealth": 50,
     "maxHealth": 50
   },
-  "BaseRegen": {
-    "regenRate": 2,
-    "waitBeforeRegen": 10
+  "Location": {},
+  "MinionMove": {
+    "movementTypes": ["walking", "leaping", "falling"]
   },
-  "BoxShape": {
-    "extents": [
-      1.5,
-      1.5,
-      1.5
+  "Network": {},
+  "NPCMovement": {},
+  "SkeletalMesh" : {
+    "mesh" : "deer",
+    "heightOffset" : -0.8,
+    "material" : "deerSkin",
+    "animation" : "deer#Idle",
+    "loop" : true
+  },
+  "Stand": {
+    "animationPool": [
+      "deer#Idle",
+      "deer#Idle",
+      "deer#Idle",
+      "deer#Bite_InPlace",
+      "deer#Yes",
+      "deer#No"
     ]
   },
   "Trigger": {
@@ -100,5 +95,12 @@
       "engine:debris",
       "engine:sensor"
     ]
+  },
+  "Walk" :{
+    "animationPool": ["deer#Walk"]
+  },
+  "WildAnimal": {
+    "name": "Deer",
+    "icon": "WildAnimals:icons#Deer"
   }
 }

--- a/assets/prefabs/animals/deer.prefab
+++ b/assets/prefabs/animals/deer.prefab
@@ -76,7 +76,9 @@
     ]
   },
   "Network": {},
-  "MinionMove": {},
+  "MinionMove": {
+    "movementTypes": ["walking", "leaping"]
+  },
   "Health": {
     "destroyEntityOnNoHealth": true,
     "currentHealth": 50,

--- a/assets/prefabs/animals/deer.prefab
+++ b/assets/prefabs/animals/deer.prefab
@@ -77,7 +77,7 @@
   },
   "Network": {},
   "MinionMove": {
-    "movementTypes": ["walking", "leaping"]
+    "movementTypes": ["walking", "leaping", "falling"]
   },
   "Health": {
     "destroyEntityOnNoHealth": true,

--- a/assets/prefabs/animals/sheepBase.prefab
+++ b/assets/prefabs/animals/sheepBase.prefab
@@ -64,15 +64,11 @@
     "maxHealth": 25
   },
   "Location": {},
-  "MinionMove": {},
+  "MinionMove": {
+    "movementTypes": ["walking", "leaping", "falling"]
+  },
   "Network": {},
   "NPCMovement": {},
-  "Trigger": {
-    "detectGroups": [
-      "engine:debris",
-      "engine:sensor"
-    ]
-  },
   "Stand": {
     "animationPool": [
       "sheep#Idle",
@@ -81,6 +77,12 @@
       "sheep#Bite_InPlace",
       "sheep#Yes",
       "sheep#No"
+    ]
+  },
+  "Trigger": {
+    "detectGroups": [
+      "engine:debris",
+      "engine:sensor"
     ]
   },
   "Walk": {

--- a/assets/prefabs/animals/sheepBase.prefab
+++ b/assets/prefabs/animals/sheepBase.prefab
@@ -1,10 +1,77 @@
 {
+  // -- Properties ---
+  "persisted": true,
+  // -- Components ---
+  "AliveCharacter": {},
+  "BaseRegen": {
+    "regenRate": 2,
+    "waitBeforeRegen": 10
+  },
   "Behavior": {
-    "tree": "Behaviors:critter"
+    "tree": "WildAnimals:lure"
+  },
+  "BoxShape": {
+    "extents": [
+      1.5,
+      1.5,
+      1.5
+    ]
+  },
+  "Character": {},
+  "CharacterMovement": {
+    "speedMultiplier": 0.3,
+    "distanceBetweenFootsteps": 0.2,
+    "height": 1.6,
+    "radius": 0.3,
+    "jumpSpeed": 12
+  },
+  "CharacterSound": {
+    "footstepSounds": [
+      "engine:FootGrass1",
+      "engine:FootGrass2",
+      "engine:FootGrass3",
+      "engine:FootGrass4",
+      "engine:FootGrass5"
+    ],
+    "footstepVolume": 0.03
+  },
+  "CreatureNameGenerator": {
+    "genderRatio": 0,
+    "nobility": 0,
+    "theme": "ANIMAL"
+  },
+  "DamageSound": {
+    "sounds": [
+      "SheepHit1",
+      "SheepHit2"
+    ]
+  },
+  "Die": {
+    "animationPool": [
+      "sheep#Death"
+    ]
+  },
+  "FindNearbyPlayers": {
+    "searchRadius": 12
   },
   "FleeOnHit": {
     "minDistance": 5,
     "speedMultiplier": 1.2
+  },
+  "Health": {
+    "destroyEntityOnNoHealth": true,
+    "currentHealth": 25,
+    "maxHealth": 25
+  },
+  "Location": {},
+  "MinionMove": {},
+  "Network": {},
+  "NPCMovement": {},
+  "Trigger": {
+    "detectGroups": [
+      "engine:debris",
+      "engine:sensor"
+    ]
   },
   "Stand": {
     "animationPool": [
@@ -21,76 +88,8 @@
       "sheep#Walk"
     ]
   },
-  "Die": {
-    "animationPool": [
-      "sheep#Death"
-    ]
-  },
-  "persisted": true,
-  "location": {},
-  "Character": {},
-  "AliveCharacter": {},
   "WildAnimal": {
     "name": "Sheep",
     "icon": "WildAnimals:icons#Sheep"
-  },
-  "NPCMovement": {},
-  "CreatureNameGenerator": {
-    "genderRatio": 0,
-    "nobility": 0,
-    "theme": "ANIMAL"
-  },
-  "CharacterMovement": {    
-    "speedMultiplier": 0.3,
-    "distanceBetweenFootsteps": 0.2,    
-    "height": 1.6,
-    "radius": 0.3,
-    "jumpSpeed": 12
-  },
-  "CharacterSound": {
-    "footstepSounds": [
-      "engine:FootGrass1",
-      "engine:FootGrass2",
-      "engine:FootGrass3",
-      "engine:FootGrass4",
-      "engine:FootGrass5"
-    ],
-    "footstepVolume": 0.03
-  },
-  "DamageSound": {
-    "sounds": [
-      "SheepHit1",
-      "SheepHit2"
-    ]
-  },
-  "Network": {},
-  "MinionMove": {},
-  "Health": {
-    "destroyEntityOnNoHealth": true,
-    "currentHealth": 25,
-    "maxHealth": 25
-  },
-  "BaseRegen": {
-    "regenRate": 2,
-    "waitBeforeRegen": 10
-  },
-  "BoxShape": {
-    "extents": [
-      1.5,
-      1.5,
-      1.5
-    ]
-  },
-  "Trigger": {
-    "detectGroups": [
-      "engine:debris",
-      "engine:sensor"
-    ]
-  },
-  "Behavior": {
-    "tree": "WildAnimals:lure"
-  },
-  "FindNearbyPlayers": {
-    "searchRadius": 12
   }
 }


### PR DESCRIPTION
Follow-up PR to Terasology/Behaviors#89.

Contributes to MovingBlocks/Terasology#4981.

I think after the migration minions that should move need to have _movement types_ defined to derive the correct pathfinding plugins.

Even if the minion behavior does not apply proper pathfinding to its movement, deciding on the next movement target may already depend on these movement types, e.g., to determine reachable blocks nearby.
