### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/wildAnimals/Death/DestroyAtAnimationEndComponent.java
+++ b/src/main/java/org/terasology/wildAnimals/Death/DestroyAtAnimationEndComponent.java
@@ -15,9 +15,9 @@ public class DestroyAtAnimationEndComponent implements Component<DestroyAtAnimat
     @Replicate
     public long deathTime;
 
-    private EntityRef instigator;
-    private EntityRef directCause;
-    private Prefab damageType;
+    public EntityRef instigator;
+    public EntityRef directCause;
+    public Prefab damageType;
 
     public DestroyAtAnimationEndComponent() {
     }


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191